### PR TITLE
Simplification of email.tmpl modifications in alertmanager-config chart

### DIFF
--- a/cluster-configs/base/alertmanager-config/files/email.tmpl
+++ b/cluster-configs/base/alertmanager-config/files/email.tmpl
@@ -1,0 +1,25 @@
+{{ define "custom_mail_subject" -}}
+{{ if eq .Status "firing" -}}
+🔥{{ .Values.cluster.name }} [{{ .CommonLabels.alertname }}] {{ .CommonLabels.instance }} is {{ .Status }}!
+{{- else -}}
+✅ {{ .Values.cluster.name }} [{{ .CommonLabels.alertname }}] {{ .CommonLabels.instance }} is {{ .Status }}!
+{{- end }}
+{{- end }}
+
+{{ define "custom_mail_html" }}
+Cluster: {{ .Values.cluster.name }}<br>
+Number of alerts: {{ len .Alerts }} <br><br>
+
+{{ range .Alerts }}
+Alert Name: {{ .Labels.alertname }}<br>
+Severity: {{ .Labels.severity }}<br>
+Namespace: {{ .Labels.namespace }}<br>
+{{ if .Annotations.description }}
+Description: {{ .Annotations.description }}<br>
+{{ end }}
+{{ if .Annotations.message }}
+Message: {{ .Annotations.message }}<br>
+{{ end }}
+<br>
+{{ end }}
+{{ end }}

--- a/cluster-configs/base/alertmanager-config/templates/alertmanager-config.yaml
+++ b/cluster-configs/base/alertmanager-config/templates/alertmanager-config.yaml
@@ -70,29 +70,5 @@ stringData:
       {{- end }}
 
   email.tmpl: |
-    {{`{{ define "custom_mail_subject" -}}`}}
-    {{`{{ if eq .Status "firing" -}}`}}
-    🔥{{ .Values.cluster.name }} [{{`{{ .CommonLabels.alertname }}] {{ .CommonLabels.instance }} is {{ .Status }}`}}!
-    {{`{{- else -}}`}}
-    ✅ {{ .Values.cluster.name }} [{{`{{ .CommonLabels.alertname }}] {{ .CommonLabels.instance }} is {{ .Status }}`}}!
-    {{`{{- end }}`}}
-    {{`{{- end }}`}}
-
-    {{`{{ define "custom_mail_html" }}`}}
-    Cluster: {{ .Values.cluster.name }}<br>
-    Number of alerts: {{`{{ len .Alerts }}`}} <br><br>
-
-    {{`{{ range .Alerts }}`}}
-    Alert Name: {{`{{ .Labels.alertname }}`}}<br>
-    Severity: {{`{{ .Labels.severity }}`}}<br>
-    Namespace: {{`{{ .Labels.namespace }}`}}<br>
-    {{`{{ if .Annotations.description }}`}}
-    Description: {{`{{ .Annotations.description }}`}}<br>
-    {{`{{ end }}`}}
-    {{`{{ if .Annotations.message }}`}}
-    Message: {{`{{ .Annotations.message }}`}}<br>
-    {{`{{ end }}`}}
-    <br>
-    {{`{{ end }}`}}
-    {{`{{ end }}`}}
+  {{- .Files.Get "files/email.tmpl" | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
Due to a fact that alertmanager and helm, both use the same templating language, there was a necessity to escape curly brackets in the email.tmpl using for example "{{`", so helm won't template values that are intended to be templated by alertmanager itself. This makes modifications of the email.tmpl tedious and unpleasant.

I was able to work around this issue by moving email.tmpl to a separate file, and importing it in original template using .Files.Get function. Now the email template is "copy pasted" as is, and we don't have to worry about escaping curly brackets.